### PR TITLE
chore(ci): name workflow "CI" and add workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
- Sets top-level workflow name to "CI" so required check appears as "CI / build".
- Adds workflow_dispatch to allow manual runs on main when needed.
- Next: update Branch protection to require "CI / build" (replace old "build").

## Summary
Describe the change and why it’s needed.

## Linked Issue
Closes #<issue-number>

## Checklist
- [ ] Tests/Checks pass locally
- [ ] Changelog updated (if user-facing change)
- [ ] Docs/README updated (if needed)
