### PR TITLE
chore(release): support prerelease tags and auto-mark prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v*.*.*'      # finals like v1.2.3
+      - 'v*.*.*-*'    # pre-releases like v1.2.3-beta, v1.2.3-rc1
 
 permissions:
   contents: write
@@ -13,11 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Build artifacts (placeholder)
         run: echo "Build your add-on zips here"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref, '-') }}
+          # files: |
+          #   dist/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Triggers on v*.*.* and v*.*.*-* (beta/rc)
- Auto-marks prerelease when tag contains a hyphen

## Summary
Describe the change and why it’s needed.

## Linked Issue
Closes #<issue-number>

## Checklist
- [ ] Tests/Checks pass locally
- [ ] Changelog updated (if user-facing change)
- [ ] Docs/README updated (if needed)
