### PR TITLE
docs: update SECURITY.md with studio@ primary contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,9 @@
 # Security Policy
 
-If you find a vulnerability, **do not** file a public issue.
-Please report it privately via the organization contact email.
+If you find a vulnerability, do not file a public issue. Please report it privately via the organization contact email.
 
-- Primary contact: studio@modlr.tools (use once live)
-- Temporary: modlrkit@gmail.com
+**Primary contact:** studio@modlr.tools  
+**Secondary contact:** support@modlr.tools  
+**General inquiries:** info@modlr.tools  
 
-We will acknowledge receipt within 72 hours.
+**Response Commitment:** We will acknowledge receipt within 72 hours.


### PR DESCRIPTION
- Set studio@modlr.tools as the primary security disclosure address
- Kept support@modlr.tools as secondary and info@modlr.tools as general
- Clarified 72-hour acknowledgement commitment

## Summary
Describe the change and why it’s needed.

## Linked Issue
Closes #<issue-number>

## Checklist
- [ ] Tests/Checks pass locally
- [ ] Changelog updated (if user-facing change)
- [ ] Docs/README updated (if needed)
